### PR TITLE
Fixed return type error on strict mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ import { Saga, Task } from "redux-saga";
  *
  * @public
  */
-export function forceReducerReload(store: {});
+export function forceReducerReload(store: {}): void;
 
 /**
  * Creates a store enhancer that when applied will setup the store to allow the


### PR DESCRIPTION
fixes
```
ERROR in c:/src/TheCoin/node_modules/redux-injectors/index.d.ts(16,17):
TS7010: 'forceReducerReload', which lacks return-type annotation, implicitly has an 'any' return type.
Version: typescript 3.7.4
```