### PR TITLE
Ask contributors to target master branch instead of dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,7 @@ project's developers might not want to merge into the project.
 Please adhere to the coding conventions used throughout a project (indentation,
 accurate comments, etc.) and any other requirements (such as test coverage).
 
-Since the `master` branch is what people actually use in production, we have a
-`dev` branch that unstable changes get merged into first. Only when we
-consider that stable we merge it into the `master` branch and release the
-changes for real.
+Please target the `master` branch with pull requests.
 
 Adhering to the following process is the best way to get your work
 included in the project:
@@ -51,11 +48,11 @@ included in the project:
 2.  If you cloned a while ago, get the latest changes from upstream:
 
     ```bash
-    git checkout dev
-    git pull upstream dev
+    git checkout master
+    git pull upstream master
     ```
 
-3.  Create a new topic branch (off the `dev` branch) to contain your feature, change, or fix:
+3.  Create a new topic branch (off the `master` branch) to contain your feature, change, or fix:
 
     ```bash
     git checkout -b <topic-branch-name>
@@ -63,10 +60,10 @@ included in the project:
 
 4.  Commit your changes in logical chunks. Please adhere to these [git commit message guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) or your code is unlikely be merged into the main project. Use Git's [interactive rebase](https://help.github.com/articles/about-git-rebase/) feature to tidy up your commits before making them public.
 
-5.  Locally merge (or rebase) the upstream dev branch into your topic branch:
+5.  Locally merge (or rebase) the upstream master branch into your topic branch:
 
     ```bash
-    git pull [--rebase] upstream dev
+    git pull [--rebase] upstream master
     ```
 
 6.  Push your topic branch up to your fork:


### PR DESCRIPTION
I think we no longer need a dev branch.

The reason for a dev branch in `react-boilerplate` makes sense, because it's a template and people make projects off of `master`

But the reason for a dev branch in this library doesn't make as much sense because that reasoning doesn't apply.  New (and potentially less stable) changes can still be merged to master and not reach consumers until it's deployed to npm.  We can even deploy release candidates (using `-rc`) based off master

To reduce overhead, we can just use master.  After this PR is merged I'll probably delete the `dev` branch